### PR TITLE
fix: update login element selector

### DIFF
--- a/downloaders/substack_archives_downloader.py
+++ b/downloaders/substack_archives_downloader.py
@@ -21,7 +21,7 @@ class SubstackArchivesDownloader(PDFDownloader):
         'get_to_sign_in_page_css': 'button.button.sign-in-link.outline-grayscale',
         'sign_in_button_css': '.button',
         'go_to_login_link_text': 'Log in',
-        'log_in_with_password_link_text': 'sign in with password',
+        'log_in_with_password_link_text': 'Sign in with password',
         'username_field_xpath': '//input[@name="email"]',
         'password_field_xpath': '//input[@name="password"]',
         'submit_button_xpath': '//button[@type="submit"]',


### PR DESCRIPTION
Error was: 

```
Please wait while we log in using the credential you provided...
Timeout exception while waiting for element to load
Something wrong happened after clicking go_to_login_button.
Please log in again or try again later.
```

Case was changed:
<img width="488" alt="image" src="https://github.com/zxt-tzx/substack-archives-downloader/assets/201897/6e46b4af-3cf9-4105-be41-03748a28e848">

However, it might be better to lowercase everything before testing against strings?